### PR TITLE
Fixed the install instructions and added the badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the README installation instructions and added the badge for the published gem
+
 ## [1.0.0] - 2025-01-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@
 <!-- Way of Working: Additional Badge Holder Start -->
 <!-- Way of Working: Badge Holder End -->
 
+[![Gem Version](https://badge.fury.io/rb/way_of_working-decision_record-madr.svg)](https://badge.fury.io/rb/way_of_working-decision_record-madr)
+
 This is a plugin for the [Way of Working](https://github.com/HealthDataInsight/way_of_working) framework. It uses [Markdown Any Decision Records (MADR)](https://adr.github.io/madr/) version 3.0.0 to capture key technical (e.g archtectural) and non-technical decisions within your repository.
 
 You can read about the general approach to capturing decisions on the [GDS Way page on Architecture Decisions](https://gds-way.cloudapps.digital/standards/architecture-decisions.html) and specifics about MADR are available at <https://adr.github.io/madr/>.
 
 ## Installation
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
-
 Install the gem and add to the application's Gemfile by executing:
 
 ```bash
-bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+bundle add way_of_working-decision_record-madr
 ```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
 ```bash
-gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+gem install way_of_working-decision_record-madr
 ```
 
 ## Usage


### PR DESCRIPTION
## What?

I've fixed the README installation instructions and added the badge for the published gem.

## Why?

It would be a security risk to change the installation documentation to refer to a rubygem name before pushing it to rubygems.org for the first time (and effectively reserving the name). Now that it has been published the documentation needs updating.

## How?

The README has been changed

## Testing?

This version of the README looks fine when viewed on GitHub at https://github.com/HealthDataInsight/way_of_working-decision_record-madr/tree/feature/published-gem-updates.

## Anything Else?

No