### PR TITLE
Removed Zeitwerk ignore to make it happier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed Zeitwerk ignore to make it happier
+
 ## [1.0.1] - 2025-10-16
 
 ### Fixed

--- a/lib/way_of_working/decision_record/madr.rb
+++ b/lib/way_of_working/decision_record/madr.rb
@@ -12,7 +12,6 @@ rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
 loader = Zeitwerk::Loader.for_gem_extension(WayOfWorking::DecisionRecord)
-loader.ignore("#{__dir__}/madr/plugin.rb")
 loader.setup
 
 module WayOfWorking

--- a/lib/way_of_working/decision_record/madr/plugin.rb
+++ b/lib/way_of_working/decision_record/madr/plugin.rb
@@ -1,1 +1,13 @@
 require 'way_of_working/decision_record/madr'
+
+# Add any plug specific code here
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      # This makes zeitwerk happy, which makes us happy too
+      module Plugin
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?

I've removed Zeitwerk ignore to make it happier

### Why?

There are circumstances where the plugin is loaded without our zeitwerk configuration which used to ignore the plugin.

### How?

This removes the ignore and adds a stub module.

### Testing?

Tests pass

### Anything else?

No