### PR TITLE
Reword "obvious" in decision-records template

### DIFF
--- a/docs/way_of_working/decision-records.md
+++ b/docs/way_of_working/decision-records.md
@@ -36,7 +36,7 @@ Applies to decisions about:
 
 - Already covered by Way of Working
 - Tactical implementation details (use code comments)
-- Temporary workarounds or obvious choices
+- Temporary workarounds or clear-cut choices
 
 ## Requirements
 

--- a/lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md
+++ b/lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md
@@ -36,7 +36,7 @@ Applies to decisions about:
 
 - Already covered by Way of Working
 - Tactical implementation details (use code comments)
-- Temporary workarounds or obvious choices
+- Temporary workarounds or clear-cut choices
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- `alex` / `retext-equality` flags the word **obvious** as potentially insensitive.
- Downstream projects that adopt [`way_of_working-for-hdi`](https://github.com/HealthDataInsight/way_of_working-for-hdi) and enable the bundled `inclusive-language` GitHub Actions workflow get a failing CI check on a file this gem renders, which is awkward — the warning is on content they didn't author.
- Replace `obvious choices` with `clear-cut choices` in both the committed doc and the template copied by `way_of_working init decision_record`. Meaning is preserved and `alex` no longer warns.

## Files changed

- `docs/way_of_working/decision-records.md`
- `lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md`

## Verification

```console
$ echo "Temporary workarounds or clear-cut choices" > /tmp/t.md && npx -y alex /tmp/t.md
/tmp/t.md: no issues found
```

## Test plan

- [ ] `bundle exec rake` still passes
- [ ] `way_of_working init decision_record` in a fresh project renders the new wording