### PR TITLE
Add archived notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # WayOfWorking::DecisionRecord::Madr
 
+> [!IMPORTANT]
+> **This repository has been archived.**
+>
+> The Decision Record (MADR) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem, where it is now a built-in, opt-in feature. Enable it by requiring it:
+>
+> ```ruby
+> require 'way_of_working/decision_record/madr'
+> ```
+>
+> Then use `way_of_working init decision_record` and `way_of_working new decision_record` as before. This repository is no longer maintained.
+
 <!-- Way of Working: Main Badge Holder Start -->
 ![Way of Working Badge](https://img.shields.io/badge/Way_of_Working-v2.0.1-%238169e3?labelColor=black)
 <!-- Way of Working: Additional Badge Holder Start -->


### PR DESCRIPTION
The Decision Record (MADR) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem as a built-in, opt-in feature. This adds an archived notice to the top of the README directing users to enable it there via `require 'way_of_working/decision_record/madr'`.

README-only change; no code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)